### PR TITLE
V0.2 overwrite project input

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,9 @@ To monitor storage use and to identify files for deletion.
 - `-iconfig_file` (`file`) a JSON configuration file.
         see repo for an example: https://github.com/eastgenomics/eggd_auto_dnanexus_data_deletion/blob/v0.1-initial_build/resources/home/dnanexus/eggd_automatic_deletion/configs/StagingArea_config.json
 
+### Optional
+- `-iproject` (`DNA nexus project id`) ID for the DNAnexus project ID (e.g. `project-xxxx`) which you want to scan for files.
+
 ## What are the outputs?
 - `outputFromConfig.txt` - a CSV file where each column is a field returned by dxpy's describe function, filtered to the subset specified in the input config.
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -11,7 +11,15 @@
       "help": "A configuration file that contains the criteria for selecting files to delete",
       "class": "file",
       "patterns": ["*.json"]
+    },
+    {
+      "name": "project",
+      "label": "project",
+      "class": "string",
+      "optional": true,
+      "help": "The project to search for files to delete. overwrites project specified in config file"
     }
+    
   ],
   "outputSpec": [
     {

--- a/resources/home/dnanexus/eggd_automatic_deletion/main.py
+++ b/resources/home/dnanexus/eggd_automatic_deletion/main.py
@@ -228,7 +228,7 @@ def main():
         )
         details.to_csv(f"{output_dest}/{output_name}", header=False, index=False)
     else:
-            print("No files found for deletion in {project} older than {older_than_months} months and matching the regex pattern(s) {file_regexs}")
+            print(f"No files found for deletion in {project} older than {older_than_months} months and matching the regex pattern(s) {file_regexs}")
 
 
 if __name__ == "__main__":

--- a/resources/home/dnanexus/eggd_automatic_deletion/main.py
+++ b/resources/home/dnanexus/eggd_automatic_deletion/main.py
@@ -167,6 +167,14 @@ def main():
         help="Path to the configuration file",
         required=True,
     )
+    args.add_argument(
+        "-p",
+        "--project",
+        type=str,
+        help="DNAnexus project ID",
+        required=False,
+    )
+
     args = args.parse_args()
 
     if not os.path.exists(args.config):
@@ -181,7 +189,10 @@ def main():
 
     try:
         # assign inputs to variables
-        project = config["parameters"]["project"]
+        if args.project:
+            project = args.project
+        else:
+            project = config["parameters"]["project"]
         output_dest = config["parameters"]["output"]
         file_regexs = config["parameters"]["file_regexs"]
         older_than_months = config["parameters"]["older_than_months"]

--- a/src/AutoDelete.sh
+++ b/src/AutoDelete.sh
@@ -10,7 +10,9 @@ main() {
     
     dx download "$config_file" -o config_file
 
-    python3 /home/dnanexus/eggd_automatic_deletion/main.py -c config_file
+    [ -n "$project" ] && project="--project ${project}" || unset project
+
+    python3 /home/dnanexus/eggd_automatic_deletion/main.py --config config_file $project 
 
 
 if [[ -s /home/dnanexus/*_files_to_delete_*.csv ]]; then


### PR DESCRIPTION
add optional project input parameter which is used over project specified in the config

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_auto_dnanexus_data_deletion/6)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**  
	- Introduced a new input option that lets you explicitly specify a project ID using a command-line flag; if provided, it overrides the project setting in the configuration.  
	- Added documentation for the new optional input parameter `-iproject`, allowing users to specify a DNAnexus project ID.  
	- Enhanced flexibility in project assignment for file deletion operations, ensuring a more intuitive user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->